### PR TITLE
Updated require-dir to work with node v8

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "merge-stream": "^1.0.0",
     "orchestrator": "^0.3.7",
     "path": "^0.11.14",
-    "require-dir": "~0.1.0",
+    "require-dir": "~0.3.2",
     "run-sequence": "^1.2.2",
     "stream-browserify": "^2.0.1",
     "through": "^2.3.6",


### PR DESCRIPTION
The error message:
```
/usr/local/lib/node_modules/gulpist/node_modules/require-dir/index.js:93
            if (!require.extensions.hasOwnProperty(ext)) {
                                    ^

TypeError: require.extensions.hasOwnProperty is not a function
    at requireDir (/usr/local/lib/node_modules/gulpist/node_modules/require-dir/index.js:93:37)
    at Object.<anonymous> (/usr/local/lib/node_modules/gulpist/lib/gulpist.js:7:1)
    at Module._compile (module.js:624:30)
    at Object.Module._extensions..js (module.js:635:10)
    at Module.load (module.js:545:32)
    at tryModuleLoad (module.js:508:12)
    at Function.Module._load (module.js:500:3)
    at Module.require (module.js:568:17)
    at require (internal/module.js:11:18)
    at Liftoff.handleArguments (/usr/local/lib/node_modules/gulp/bin/gulp.js:116:3)
```

The explanation and fix is described in detail here: https://stackoverflow.com/a/45545503

I don't think I have the rights to publish a new version of gulpist. If we decide to move forward with this PR this needs to be done by someone else :)